### PR TITLE
Added title attribute to video to make video name obvious

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ class NoSleep {
       // Set up no sleep video element
       this.noSleepVideo = document.createElement('video')
 
+      this.noSleepVideo.setAttribute('title', 'No Sleep')
       this.noSleepVideo.setAttribute('playsinline', '')
       this.noSleepVideo.setAttribute('src', mediaFile)
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,7 @@ module.exports = {
         use: {
           loader: 'babel-loader',
           options: {
-            presets: ['es2015']
+            presets: ['env']
           }
         }
       }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,7 @@ module.exports = {
         use: {
           loader: 'babel-loader',
           options: {
-            presets: ['env']
+            presets: ['es2015']
           }
         }
       }


### PR DESCRIPTION
Since this shim is intended for mobile devices, its almost impossible to hide the fact that video play is being used to keep the screen awake.  When manually locking the phone or in control center on iOS you can see the name of the video and it's just the src name `data:video/mp4;base64,AAAAIGZ0eXB...`.  This pull request sets the title of the video to make it clear what the video content is intended for.

![img_8766e28e38c2-1](https://user-images.githubusercontent.com/1904364/30786137-fa8b4366-a136-11e7-9cde-bc3fdd66b59a.jpeg)

(also the webpack was broken with `env` for the babel preset, but no `env` in `.babelrc` so I fixed it ;)
