### PR TITLE
Point main to dist/NoSleep.min.js instead of non-ES5 version in src/

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "display",
     "sleep"
   ],
-  "main": "src/index.js",
+  "main": "dist/NoSleep.min.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/richtr/NoSleep.js.git"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "sleep"
   ],
   "main": "dist/NoSleep.min.js",
+  "module": "src/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/richtr/NoSleep.js.git"


### PR DESCRIPTION
Fixes https://github.com/richtr/NoSleep.js/issues/46.