### PR TITLE
Rework oldIOS wake lock redirect URL

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,8 +30,10 @@ class NoSleep {
     if (oldIOS) {
       this.disable()
       this.noSleepTimer = window.setInterval(function () {
-        window.location.href = window.location.href.split('#')[0]
-        window.setTimeout(window.stop, 0)
+        if (!document.hidden) {
+          window.location.href = window.location.href.split('#')[0]
+          window.setTimeout(window.stop, 0)
+        }
       }, 15000)
     } else {
       this.noSleepVideo.play()

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ class NoSleep {
     if (oldIOS) {
       this.disable()
       this.noSleepTimer = window.setInterval(function () {
-        window.location.href = window.location.href
+        window.location.href = window.location.href.split('#')[0]
         window.setTimeout(window.stop, 0)
       }, 15000)
     } else {

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ class NoSleep {
     if (oldIOS) {
       this.disable()
       this.noSleepTimer = window.setInterval(function () {
-        window.location.href = '/'
+        window.location.href = window.location.href
         window.setTimeout(window.stop, 0)
       }, 15000)
     } else {


### PR DESCRIPTION
Reverts https://github.com/richtr/NoSleep.js/pull/5 but takes in to account the [original comment](https://stackoverflow.com/questions/9709891/prevent-ios-mobile-safari-from-going-idle-auto-locking-sleeping#comment48765157_24351683) that led to that change to provide a better fix.

Fixes https://github.com/richtr/NoSleep.js/issues/42.