### PR TITLE
Update readme describing how to use es6 module imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A new build of [NoSleep.js](https://github.com/richtr/NoSleep.js/blob/master/dis
 Import ES6 module:
 
 ```javascript
-import NoSleep from 'nosleep.js'
+import NoSleep from 'nosleep.js';
 ```
 
 Create a new NoSleep object and then enable or disable it when needed.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ To build this library run:
 A new build of [NoSleep.js](https://github.com/richtr/NoSleep.js/blob/master/dist/NoSleep.js) and [NoSleep.min.js](https://github.com/richtr/NoSleep.js/blob/master/dist/NoSleep.min.js) will now be available in the `/dist` directory.
 
 ## Usage
+Import ES6 module:
+
+```javascript
+import NoSleep from 'nosleep.js'
+```
 
 Create a new NoSleep object and then enable or disable it when needed.
 


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **Docs/metadata update**

### Motivation / Use-Case

I wanted to use this module real quick in a vue/webpack project and got impatient when I did not find a module import read-me information. I found it somewhere in an issue, but it was wrong:
`import NoSleep from 'nosleep'`

Then I checked the folders and realized it was 
`import NoSleep from 'nosleep.js'`

I just wanted to share that.
I also saw that the PR #33 did mention that the docs needed an update. So this is just a tiny part of that.

### Breaking Changes

No Breaking changes
