### PR TITLE
Fixing the disabling of a null instance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,8 @@ class NoSleep {
 
   disable() {
     if (nativeWakeLock) {
-      this._wakeLock.release();
+      if(this._wakeLock)
+            this._wakeLock.release();
       this._wakeLock = null;
     } else if (oldIOS) {
       if (this.noSleepTimer) {


### PR DESCRIPTION
Add check for this._wakeLock to see if instance is currently running before calling release() method.
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Fixes #105 

### Breaking Changes

Needs regression tests

### Additional Info
n/a