### PR TITLE
fix `nativeWakeLock` code to be consistent with other methods

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,8 +102,10 @@ class NoSleep {
 
   disable() {
     if (nativeWakeLock) {
-      this._wakeLock.release();
-      this._wakeLock = null;
+      if (this._wakeLock) {
+        this._wakeLock.release();
+        this._wakeLock = null;
+      }
     } else if (oldIOS) {
       if (this.noSleepTimer) {
         console.warn(`


### PR DESCRIPTION
Using `nativeWakeLock`, calling `disable` when it's not enabled results in thrown exception.
`Cannot read property 'release' of null`

The other 2 methods (`oldIOS` and the video method) don't throw exception calling `disable` when it's not enabled.

This change makes it so all 3 methods do nothing if `disable` is called while already disabled.

Note the documentation for `HTMLMediaElement.pause()`
> if the media is already in a paused state this method will have no effect

https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/pause

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

inconsistent behavior between the different ways of preventing sleep

### Breaking Changes

If someone was relying on this inconsistency for some reason...

### Additional Info
